### PR TITLE
feat: 启用 465 stmp ssl 以解决部分邮箱登陆失败问题

### DIFF
--- a/src/main/java/lx/ZdmCrawler.java
+++ b/src/main/java/lx/ZdmCrawler.java
@@ -104,7 +104,9 @@ public class ZdmCrawler {
     public static void sendEmail(String text) {
         Properties props = new Properties();
         props.setProperty("mail.smtp.host", System.getenv("emailHost"));
+        props.setProperty("mail.smtp.port", "465");
         props.setProperty("mail.smtp.auth", "true");
+        props.setProperty("mail.smtp.ssl.enable", "true");
         try {
             Session session = Session.getDefaultInstance(props, new Authenticator() {
                 @Override
@@ -124,5 +126,4 @@ public class ZdmCrawler {
             throw new RuntimeException("邮件发送失败");
         }
     }
-
 }


### PR DESCRIPTION
**该 PR 是将全部邮箱 smtp 请求切换到 stmps**，在 qq 邮箱上能支持，其他邮箱暂无验证

> link: https://github.com/lx1169732264/zdm/issues/3

调整使用 465 smtp ssl 端口进行连接，可解决 qq 邮箱新授权码不支持明文 stmp 问题

```
javax.mail.AuthenticationFailedException: 530 Login fail. A secure connection is requiered(such as ssl). More information at http://service.mail.qq.com/cgi-bin/help?id=28
	at com.sun.mail.smtp.SMTPTransport$Authenticator.authenticate(SMTPTransport.java:965)
	at com.sun.mail.smtp.SMTPTransport.authenticate(SMTPTransport.java:876)
	at com.sun.mail.smtp.SMTPTransport.protocolConnect(SMTPTransport.java:780)
	at javax.mail.Service.connect(Service.java:388)
	at javax.mail.Service.connect(Service.java:246)
	at javax.mail.Service.connect(Service.java:195)
	at javax.mail.Transport.send0(Transport.java:254)
	at javax.mail.Transport.send(Transport.java:124)
	at lx.ZdmCrawler.sendEmail(ZdmCrawler.java:121)
	at lx.ZdmCrawler.main(ZdmCrawler.java:97)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:87)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:50)
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:51)
```

调整之后能正常执行

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/47c59a0b-1693-45d6-a400-e3c879660441">
